### PR TITLE
[DEV-3370] TypeError happened in mu-switch

### DIFF
--- a/src/internal/mixins/select.js
+++ b/src/internal/mixins/select.js
@@ -35,7 +35,7 @@ export default function (type = 'checkbox') { // checkbox
       },
       end (event) {
         if (this.disabled) return;
-        if (this.ripple) this.$refs.ripple.end();
+        if (this.ripple && this.$refs.ripple) this.$refs.ripple.end();
         if (event) this.$emit(event.type, event);
       },
       handleClick (e) {


### PR DESCRIPTION
Implementeert [deze monkey patch van ruud](https://github.com/Jobport/jobport2/pull/1915) daadwerkelijk in muse-ui zelf.

Blijkbaar gaat er toch iets fout en word de monkey patch code niet gebruik/overschreven, hoe dan ook blijft de [error](https://appsignal.com/jobport-bv/sites/5e340d6f14ad667d92760c05/exceptions/incidents/16?timestamp=2021-03-30T06:24:01Z) terug komen. 
Hopelijk hierna niet meer.

Tevens zijn de monkey patches niet meer nodig nu we muse gewoon zelf kunnen aanpassen en updaten.